### PR TITLE
Add error check in Ex_5.8_day_date.c

### DIFF
--- a/languages/cprogs/Ex_5.8_day_date.c
+++ b/languages/cprogs/Ex_5.8_day_date.c
@@ -1,3 +1,6 @@
+/*
+ * Error check in day_of_year and month_day
+ */
 #include<stdio.h>
 
 static char daytab[2][13]={
@@ -6,15 +9,24 @@ static char daytab[2][13]={
 };
 
 int day_of_year(int year,int month,int day);
-void month_day(int year,int yearday);
+void month_day(int year,int yearday, int *month, int *day);
 
 int main(void)
 {
-	int day,mo,dat;
+	int yearday,month,day;
 
-	day=day_of_year(1988,2,29);
-	printf("%d\n",day);
-	month_day(1988,60);
+	yearday=day_of_year(1988,2,29);
+	printf("%d\n", yearday);
+
+	yearday=day_of_year(2020,2,31);
+	printf("%d\n", yearday);
+
+	month_day(1988,60, &month, &day);
+	printf("Month: %d, Day: %d\n", month, day);
+
+	month_day(1999,366, &month, &day);
+	printf("Month: %d, Day: %d\n", month, day);
+
 	return 0;
 }
 
@@ -25,6 +37,9 @@ int day_of_year(int year,int month,int day)
 	int i,leap;
 
 	leap = year % 4 == 0 && year%100 != 0 || year%400 == 0;
+
+	if(year < 1 || month < 1 || month > 12 || day < 1 || day > daytab[leap][month])
+		return -1;
 	
 	for(i=1;i<month;i++)
 		day += daytab[leap][i];
@@ -34,16 +49,22 @@ int day_of_year(int year,int month,int day)
 
 /* month_day: set month,day from day of year */
 
-void month_day(int year,int yearday)
+void month_day(int year,int yearday, int *month, int *day)
 {
 	int i,leap;
 
 	leap = year % 4 == 0 && year%100 != 0 || year%400 == 0;
 
+	if(year < 1 || yearday < 1 || yearday > (leap? 366 : 365))
+	{
+		*month = -1;
+		*day = -1;
+		return;
+	}
+
 	for(i=1;yearday > daytab[leap][i];i++)
 		yearday -= daytab[leap][i];
 
-	printf("Month: %d, Day: %d\n", i, yearday);
-
+	*month = i;
+	*day = yearday;
 }
-


### PR DESCRIPTION
Exercise 5-8 of K&R asks to put error checking in functions day_of_year and month_day. There is no error checking in [Ex_5.8_day_date.c](https://github.com/uthcode/learntosolveit/blob/master/languages/cprogs/Ex_5.8_day_date.c) right now. So I added that.
