### PR TITLE
Update Ex_4.1_strindex_rightmost.c 

### DIFF
--- a/languages/cprogs/Ex_4.1_strindex_rightmost.c
+++ b/languages/cprogs/Ex_4.1_strindex_rightmost.c
@@ -27,7 +27,7 @@ int mstrindex(char s[],char t[])
 
     for(i=0;s[i]!='\0';i++)
     {
-        for(j=i,k=0;t[k]!='\0' && s[j]==t[k];j++,k++)
+        for(j=i,k=0;t[k]!='\0' || s[j]==t[k];j++,k++)
             ;
         if(k>0 && t[k] == '\0')
             result = i;


### PR DESCRIPTION
The && caused return value of -1 despite matching instance of pattern in line, due to && operand checking for both variables inside the nested for loop to return true. The || operand solves this by returning true value if any of two is true. 
mstrindex should now return the position of the rightmost occurrence of t in s, that is 11 as desired.