### PR TITLE
Update Ex_5.1_getint.c

### DIFF
--- a/languages/cprogs/Ex_5.1_getint.c
+++ b/languages/cprogs/Ex_5.1_getint.c
@@ -59,11 +59,9 @@ int getint(int *pn)
 
 int main(void)
 {
-	int n,s,array[SIZE],getint(int *);
+	int n,s,array[SIZE];
 	
-	for(n=0;n<SIZE && getint(&array[n]) !=EOF; (res!=0) ? n++:0 ){
-	   /* For debug purposes */
-	   /* ( (res!=0) ? n++:0 ) will add only valid values to the array */
+	for(n=0;n<SIZE && getint(&array[n]) !=EOF; n++){
 	   printf("storing in n = %d, getint %d\n", n, array[n]);
 	}
 


### PR DESCRIPTION
1. Removed the "debugging purposes" part on line 64 due to having no purpose excepting making program not run, cause "res" is not defined in any shape or form.
2. Removed "getint(int *) from line 62, due to it already being a function, this resulted in host of problems when trying to initialize it inside main.
As a result of these changes, the program is functional