### PR TITLE
Update Ex_5.5_strncpy.c

### DIFF
--- a/languages/cprogs/Ex_5.5_strncpy.c
+++ b/languages/cprogs/Ex_5.5_strncpy.c
@@ -18,7 +18,7 @@ void mystrncpy(char *, char *, int);
 void mystrncat(char *, char *, char *, int);
 int mystrncmp(char *, char *, int);
 
-int mystrlen(char *s);
+int mystrnlen(char *s);
 
 int main(int argc, char *argv[])
 {
@@ -77,7 +77,7 @@ void mystrncpy(char *dest,char *source,int n)
     int extra = mystrnlen(dest) - n;
 
     while (extra-- > 0) {
-    	*dest++;
+    	dest++;
     }
 
     *dest = '\0';


### PR DESCRIPTION
2 minor fixes: first function call of mystrnlen had a typo and as such produced wimplicit warning, and *dest++ is not doing anything except pointing, its supposed to rather increment, so changed it to dest++.