### PR TITLE
Update Ex_5.14_sortrevnum.c

### DIFF
--- a/languages/cprogs/Ex_5.14_sortrevnum.c
+++ b/languages/cprogs/Ex_5.14_sortrevnum.c
@@ -48,7 +48,7 @@ int main(int argc,char *argv[])
 			if(option & NUMERIC)
 				myqsort((void **)lineptr,0,nlines -1,(int (*)(void *,void *))numcmp);
 			else
-				myqsort((void **)lineptr,0,nlines -1,(int (*)(void *,void *))numcmp);
+				myqsort((void **)lineptr,0,nlines -1,(int (*)(void *,void *))strcmp);
 			writelines(lineptr,nlines,option & DECR);
 		}
 		else


### PR DESCRIPTION
fixed line 50 else statement, where it had no purpose due to both function pointers having a same expression.